### PR TITLE
fix: swap `duneApiKey` prop for `duneConfig`

### DIFF
--- a/references/relay-kit/ui/getting-started.mdx
+++ b/references/relay-kit/ui/getting-started.mdx
@@ -55,20 +55,20 @@ const wagmiConfig = createConfig({
 const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
-      <RelayKitProvider options={{
-          appName: 'Relay Demo',
-          appFees: [
-            {
-              recipient: '0x0000000000000000000000000000000000000000',
-              fee: '100' // 1%
-            }
-          ],
-        duneConfig: {
+		<RelayKitProvider options={{
+			appName: 'Relay Demo',
+			appFees: [
+			  {
+				recipient: '0x0000000000000000000000000000000000000000',
+				fee: '100' // 1%
+			  }
+			],
+			duneConfig: {
 				apiKey: "YOUR_DUNE_KEY",
-			  },
-          chains,
-          baseApiUrl: MAINNET_RELAY_API
-        }}>
+			},
+			chains,
+			baseApiUrl: MAINNET_RELAY_API
+		  }}>
         <WagmiProvider config={wagmiConfig}>
           <YourApp />
         </WagmiProvider>
@@ -132,9 +132,9 @@ const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <RelayKitProvider options={{
-			  duneConfig: {
-				  apiKey: "YOUR_DUNE_KEY",
-			    },
+		  duneConfig: {
+			apiKey: "YOUR_DUNE_KEY",
+		  },
           chains,
           baseApiUrl: MAINNET_RELAY_API
         }}>

--- a/references/relay-kit/ui/getting-started.mdx
+++ b/references/relay-kit/ui/getting-started.mdx
@@ -62,8 +62,10 @@ const App = () => {
               recipient: '0x0000000000000000000000000000000000000000',
               fee: '100' // 1%
             }
-          ]
-          duneApiKey: "YOUR_DUNE_KEY",
+          ],
+        duneConfig: {
+				apiKey: "YOUR_DUNE_KEY",
+			  },
           chains,
           baseApiUrl: MAINNET_RELAY_API
         }}>
@@ -130,7 +132,9 @@ const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <RelayKitProvider options={{
-          duneApiKey: "YOUR_DUNE_KEY",
+			  duneConfig: {
+				  apiKey: "YOUR_DUNE_KEY",
+			    },
           chains,
           baseApiUrl: MAINNET_RELAY_API
         }}>


### PR DESCRIPTION
`RelayKitProvider` options expects a duneConfig property and this PR aims to fix this within the docs, plus also fixes a comma missing after `appFees` array.

RelayKitProvider expects:

```typescript
(property) duneConfig?: {
    apiBaseUrl?: string;
    apiKey?: string;
} | undefined
```